### PR TITLE
[#156]feat: 회원가입 체크 상태관리 enum으로 관리하고 비밀번호가 일치하지 않습니다 비밀번호 확인에 가까이 붙이기

### DIFF
--- a/src/pages/Group/Group.tsx
+++ b/src/pages/Group/Group.tsx
@@ -13,9 +13,11 @@ interface Classroom {
 
 interface GroupData {
   host: {
+    classroomCount: number;
     classrooms: Classroom[];
   };
   guest: {
+    classroomCount: number;
     classrooms: Classroom[];
   };
 }
@@ -31,10 +33,16 @@ const Group = () => {
   const [hostClassRooms, setHostClassRooms] = useState<Classroom[]>([]);
   const [guestClassRooms, setGuestClassRooms] = useState<Classroom[]>([]);
   const [createClassName, setCreateCalssName] = useState<string | undefined>();
+  const [groupCount, setGroupCount] = useState<number>();
+  const [groupTotalPeople, setTotalPeople] = useState<number>();
   useEffect(() => {
     if (data) {
       setHostClassRooms(data.host.classrooms);
       setGuestClassRooms(data.guest.classrooms);
+      setGroupCount(data.host.classroomCount + data.guest.classroomCount);
+      const totalHost = data.host.classrooms.reduce((acc: number, item) => acc + item.totalPeople, 0);
+      const totalGuest = data.guest.classrooms.reduce((acc: number, item) => acc + item.totalPeople, 0);
+      setTotalPeople(totalHost + totalGuest);
     }
   }, [data]);
   const changeCreateClassName = (e: ChangeEvent<HTMLInputElement>) => {
@@ -77,11 +85,11 @@ const Group = () => {
             <ul className="user-group-data">
               <li>
                 <p>생성된 그룹 수</p>
-                <p>8</p>
+                <p>{groupCount}</p>
               </li>
               <li>
                 <p>전체 학생 수</p>
-                <p>400</p>
+                <p>{groupTotalPeople}</p>
               </li>
             </ul>
             <label htmlFor="addgroup">그룹 생성</label>

--- a/src/pages/Signup/components/SignupWrap.tsx
+++ b/src/pages/Signup/components/SignupWrap.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, ChangeEvent, FormEvent, useContext } from "react";
 import ConsentInformationModal from "./ConsentInformationModal";
 import TermsOfServiceModal from "./TermsOfServiceModal";
 import { useMutation } from "@tanstack/react-query";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { TrySignupContext } from "../Signup";
 import cx from "classnames";
 import axios from "axios";
@@ -13,7 +13,21 @@ interface FormData {
   password: string;
   confirmPassword: string;
 }
-
+enum ContainsTwoTypes {
+  Gray = "gray",
+  Red = "red",
+  Green = "green",
+}
+enum MoreOrLess {
+  Gray = "gray",
+  Red = "red",
+  Green = "green",
+}
+enum ConsecutiveChar {
+  Gray = "gray",
+  Red = "red",
+  Green = "green",
+}
 const SignupWrap = () => {
   const [formData, setFormData] = useState<FormData>({
     username: "",
@@ -26,9 +40,9 @@ const SignupWrap = () => {
   const phoneNumberRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const [isContainsTwoTypes, setContainsTwoTypes] = useState<number>(0);
-  const [isMoreOrLess, setMoreOrLess] = useState<number>(0);
-  const [isConsecutiveChar, setConsecutiveChar] = useState<number>(0);
+  const [containsTwoTypes, setContainsTwoTypes] = useState<ContainsTwoTypes>(ContainsTwoTypes.Gray);
+  const [moreOrLess, setMoreOrLess] = useState<MoreOrLess>(MoreOrLess.Gray);
+  const [consecutiveChar, setConsecutiveChar] = useState<ConsecutiveChar>(ConsecutiveChar.Gray);
   const [isViewHidden, setIsViewHidden] = useState<boolean>(true);
   const [isViewHiddenConfirm, setIsViewHiddenConfirm] = useState<boolean>(true);
   const [isValidEmail, setValidEmail] = useState<number>(0); // 이메일이 유효한지 체크하는 state
@@ -101,28 +115,28 @@ const SignupWrap = () => {
       name === "password" &&
       /^(?:(?=.*[a-zA-Z])(?=.*\d)|(?=.*[a-zA-Z])(?=.*[\W_])|(?=.*\d)(?=.*[\W_]))/.test(trimmedValue)
     ) {
-      setContainsTwoTypes(2);
+      setContainsTwoTypes(ContainsTwoTypes.Green);
     } else {
-      setContainsTwoTypes(1);
+      setContainsTwoTypes(ContainsTwoTypes.Red);
     }
 
     // 비밀번호 입력 시, 8자 이상 20자 이하 여부 체크
     if (name === "password" && trimmedValue.length >= 8 && trimmedValue.length <= 20) {
-      setMoreOrLess(2);
+      setMoreOrLess(MoreOrLess.Green);
     } else {
-      setMoreOrLess(1);
+      setMoreOrLess(MoreOrLess.Red);
     }
     // 비밀번호 입력 시, 연속 3자 이상 동일한 문자/숫자 제외 여부 체크
     if (name === "password" && !/(.)\1{2,}/.test(trimmedValue)) {
-      setConsecutiveChar(2);
+      setConsecutiveChar(ConsecutiveChar.Green);
     } else {
-      setConsecutiveChar(1);
+      setConsecutiveChar(ConsecutiveChar.Red);
     }
     // 비밀번호 다 지우면 초기화
     if (name == "password" && trimmedValue.length === 0) {
-      setContainsTwoTypes(0);
-      setMoreOrLess(0);
-      setConsecutiveChar(0);
+      setContainsTwoTypes(ContainsTwoTypes.Gray);
+      setMoreOrLess(MoreOrLess.Gray);
+      setConsecutiveChar(ConsecutiveChar.Gray);
     }
     setFormData((prevData) => ({ ...prevData, [name]: trimmedValue }));
   };
@@ -173,9 +187,9 @@ const SignupWrap = () => {
       setValidPhoneNumber(1);
       return;
     }
-    if (isContainsTwoTypes === 1 || isContainsTwoTypes === 0) {
+    if (containsTwoTypes === "red" || containsTwoTypes === "gray") {
       passwordRef.current?.focus();
-      setContainsTwoTypes(1);
+      setContainsTwoTypes(ContainsTwoTypes.Red);
       return;
     }
     if (isValidConfirmPassword === 1 || isValidConfirmPassword === 0) {
@@ -188,7 +202,7 @@ const SignupWrap = () => {
       setValidConfirmPassword(1);
       return;
     }
-    if (isValidEmail === 2 && isValidPhoneNumber === 2 && isValidConfirmPassword && isContainsTwoTypes === 2) {
+    if (isValidEmail === 2 && isValidPhoneNumber === 2 && isValidConfirmPassword && containsTwoTypes === "green") {
       mutation.mutate(formData);
       return;
     }
@@ -199,23 +213,24 @@ const SignupWrap = () => {
   const toggleConfirmPasswordVisibility = () => {
     setIsViewHiddenConfirm(() => !isViewHiddenConfirm);
   };
-  const getIconSrc = (isContainsTwoTypes: number) => {
-    switch (isContainsTwoTypes) {
-      case 0:
+  const getIconSrc = (flag: string) => {
+    console.log(flag);
+    switch (flag) {
+      case "gray":
         return "/image/icon_check.svg";
-      case 1:
+      case "red":
         return "/image/icon_x_red.svg";
-      default:
+      case "green":
         return "/image/icon_check_green.svg";
+      default:
+        null;
     }
   };
   const getViewHiddenIconSrc = (isViewHidden: boolean) => {
-    switch (isViewHidden) {
-      case true:
-        return "/image/icon_eye.svg";
-      case false:
-        return "/image/icon_eye_off.svg";
+    if (isViewHidden) {
+      return "/image/icon_eye.svg";
     }
+    return "/image/icon_eye_off.svg";
   };
   return (
     <>
@@ -291,10 +306,10 @@ const SignupWrap = () => {
               <input
                 className={cx({
                   mb5: true,
-                  "border-red": isContainsTwoTypes === 1,
-                  "input-text-red": isContainsTwoTypes === 1,
-                  "border-green": isContainsTwoTypes === 2,
-                  "input-text-green": isContainsTwoTypes === 2,
+                  "border-red": containsTwoTypes === "red",
+                  "input-text-red": containsTwoTypes === "red",
+                  "border-green": containsTwoTypes === "green",
+                  "input-text-green": containsTwoTypes === "green",
                 })}
                 type={isViewHidden ? "password" : "text"}
                 ref={passwordRef}
@@ -312,22 +327,22 @@ const SignupWrap = () => {
             </div>
             <div className="guide-section">
               <div className="guide">
-                <img src={getIconSrc(isContainsTwoTypes)} alt="체크" />
+                <img src={getIconSrc(containsTwoTypes)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": isContainsTwoTypes === 2,
-                    "text-red": isContainsTwoTypes === 1,
+                    "text-green": containsTwoTypes === "green",
+                    "text-red": containsTwoTypes === "red",
                   })}
                 >
                   영문/숫자/특수문자 중, 2가지 이상 포함
                 </p>
               </div>
               <div className="guide">
-                <img src={getIconSrc(isMoreOrLess)} alt="체크" />
+                <img src={getIconSrc(moreOrLess)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": isMoreOrLess === 2,
-                    "text-red": isMoreOrLess === 1,
+                    "text-green": moreOrLess === "green",
+                    "text-red": moreOrLess === "red",
                   })}
                 >
                   8자 이상 32자 이하 입력 (공백 제외)
@@ -335,11 +350,11 @@ const SignupWrap = () => {
               </div>
 
               <div className="guide">
-                <img src={getIconSrc(isConsecutiveChar)} alt="체크" />
+                <img src={getIconSrc(consecutiveChar)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": isConsecutiveChar === 2,
-                    "text-red": isConsecutiveChar === 1,
+                    "text-green": consecutiveChar === "green",
+                    "text-red": consecutiveChar === "red",
                   })}
                 >
                   연속 3자 이상 동일한 문자/숫자 제외

--- a/src/pages/Signup/components/SignupWrap.tsx
+++ b/src/pages/Signup/components/SignupWrap.tsx
@@ -13,21 +13,12 @@ interface FormData {
   password: string;
   confirmPassword: string;
 }
-enum ContainsTwoTypes {
+enum CheckType {
   Gray = "gray",
   Red = "red",
   Green = "green",
 }
-enum MoreOrLess {
-  Gray = "gray",
-  Red = "red",
-  Green = "green",
-}
-enum ConsecutiveChar {
-  Gray = "gray",
-  Red = "red",
-  Green = "green",
-}
+
 const SignupWrap = () => {
   const [formData, setFormData] = useState<FormData>({
     username: "",
@@ -40,14 +31,14 @@ const SignupWrap = () => {
   const phoneNumberRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const [containsTwoTypes, setContainsTwoTypes] = useState<ContainsTwoTypes>(ContainsTwoTypes.Gray);
-  const [moreOrLess, setMoreOrLess] = useState<MoreOrLess>(MoreOrLess.Gray);
-  const [consecutiveChar, setConsecutiveChar] = useState<ConsecutiveChar>(ConsecutiveChar.Gray);
+  const [containsTwoTypes, setContainsTwoTypes] = useState<CheckType>(CheckType.Gray);
+  const [moreOrLess, setMoreOrLess] = useState<CheckType>(CheckType.Gray);
+  const [consecutiveChar, setConsecutiveChar] = useState<CheckType>(CheckType.Gray);
   const [isViewHidden, setIsViewHidden] = useState<boolean>(true);
   const [isViewHiddenConfirm, setIsViewHiddenConfirm] = useState<boolean>(true);
-  const [isValidEmail, setValidEmail] = useState<number>(0); // 이메일이 유효한지 체크하는 state
-  const [isValidPhoneNumber, setValidPhoneNumber] = useState<number>(0); // 전화번호가 유효한지 체크하는 state
-  const [isValidConfirmPassword, setValidConfirmPassword] = useState<number>(0); // 비밀번호가 일치하는지 체크하는 state
+  const [isValidEmail, setValidEmail] = useState<CheckType>(CheckType.Gray); // 이메일이 유효한지 체크하는 state
+  const [isValidPhoneNumber, setValidPhoneNumber] = useState<CheckType>(CheckType.Gray); // 전화번호가 유효한지 체크하는 state
+  const [isValidConfirmPassword, setValidConfirmPassword] = useState<CheckType>(CheckType.Gray); // 비밀번호가 일치하는지 체크하는 state
   const [isTermsOfServiceModalOpen, setIsTermsOfServiceModalOpen] = useState<boolean>(false);
   const context = useContext(TrySignupContext);
   if (!context) {
@@ -87,9 +78,9 @@ const SignupWrap = () => {
 
     // 유효성 검사
     if (/^010-\d{3,4}-\d{4}$/.test(formattedNumber)) {
-      setValidPhoneNumber(2);
+      setValidPhoneNumber(CheckType.Green);
     } else {
-      setValidPhoneNumber(1);
+      setValidPhoneNumber(CheckType.Red);
     }
 
     // 상태 업데이트
@@ -100,9 +91,9 @@ const SignupWrap = () => {
     const { name, value } = e.target;
     const trimmedValue = value.replace(/\s/g, "");
     if (/\S+@\S+\.\S+/.test(trimmedValue)) {
-      setValidEmail(2);
+      setValidEmail(CheckType.Green);
     } else {
-      setValidEmail(1);
+      setValidEmail(CheckType.Red);
     }
 
     setFormData((prevData) => ({ ...prevData, [name]: trimmedValue }));
@@ -115,28 +106,28 @@ const SignupWrap = () => {
       name === "password" &&
       /^(?:(?=.*[a-zA-Z])(?=.*\d)|(?=.*[a-zA-Z])(?=.*[\W_])|(?=.*\d)(?=.*[\W_]))/.test(trimmedValue)
     ) {
-      setContainsTwoTypes(ContainsTwoTypes.Green);
+      setContainsTwoTypes(CheckType.Green);
     } else {
-      setContainsTwoTypes(ContainsTwoTypes.Red);
+      setContainsTwoTypes(CheckType.Red);
     }
 
     // 비밀번호 입력 시, 8자 이상 20자 이하 여부 체크
     if (name === "password" && trimmedValue.length >= 8 && trimmedValue.length <= 20) {
-      setMoreOrLess(MoreOrLess.Green);
+      setMoreOrLess(CheckType.Green);
     } else {
-      setMoreOrLess(MoreOrLess.Red);
+      setMoreOrLess(CheckType.Red);
     }
     // 비밀번호 입력 시, 연속 3자 이상 동일한 문자/숫자 제외 여부 체크
     if (name === "password" && !/(.)\1{2,}/.test(trimmedValue)) {
-      setConsecutiveChar(ConsecutiveChar.Green);
+      setConsecutiveChar(CheckType.Green);
     } else {
-      setConsecutiveChar(ConsecutiveChar.Red);
+      setConsecutiveChar(CheckType.Red);
     }
     // 비밀번호 다 지우면 초기화
     if (name == "password" && trimmedValue.length === 0) {
-      setContainsTwoTypes(ContainsTwoTypes.Gray);
-      setMoreOrLess(MoreOrLess.Gray);
-      setConsecutiveChar(ConsecutiveChar.Gray);
+      setContainsTwoTypes(CheckType.Gray);
+      setMoreOrLess(CheckType.Gray);
+      setConsecutiveChar(CheckType.Gray);
     }
     setFormData((prevData) => ({ ...prevData, [name]: trimmedValue }));
   };
@@ -145,9 +136,9 @@ const SignupWrap = () => {
     const trimmedValue = value.replace(/\s/g, "");
     if (formData.password === trimmedValue) {
       // 비밀번호와 비밀번호 확인이 일치하는지 체크
-      setValidConfirmPassword(2);
+      setValidConfirmPassword(CheckType.Green);
     } else {
-      setValidConfirmPassword(1); // 비밀번호와 비밀번호 확인이 일치하지 않을 때
+      setValidConfirmPassword(CheckType.Red); // 비밀번호와 비밀번호 확인이 일치하지 않을 때
     }
 
     setFormData((prevData) => ({ ...prevData, [name]: trimmedValue }));
@@ -177,32 +168,37 @@ const SignupWrap = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (isValidEmail === 1 || isValidEmail === 0) {
+    if (isValidEmail === "red" || isValidEmail === "gray") {
       emailRef.current?.focus();
-      setValidEmail(1);
+      setValidEmail(CheckType.Red);
       return;
     }
-    if (isValidPhoneNumber === 1 || isValidPhoneNumber === 0) {
+    if (isValidPhoneNumber === "red" || isValidPhoneNumber === "gray") {
       phoneNumberRef.current?.focus();
-      setValidPhoneNumber(1);
+      setValidPhoneNumber(CheckType.Red);
       return;
     }
     if (containsTwoTypes === "red" || containsTwoTypes === "gray") {
       passwordRef.current?.focus();
-      setContainsTwoTypes(ContainsTwoTypes.Red);
+      setContainsTwoTypes(CheckType.Red);
       return;
     }
-    if (isValidConfirmPassword === 1 || isValidConfirmPassword === 0) {
+    if (isValidConfirmPassword === "red" || isValidConfirmPassword === "gray") {
       confirmPasswordRef.current?.focus();
-      setValidConfirmPassword(1);
+      setValidConfirmPassword(CheckType.Red);
       return;
     }
     if (formData.password !== formData.confirmPassword) {
       confirmPasswordRef.current?.focus();
-      setValidConfirmPassword(1);
+      setValidConfirmPassword(CheckType.Red);
       return;
     }
-    if (isValidEmail === 2 && isValidPhoneNumber === 2 && isValidConfirmPassword && containsTwoTypes === "green") {
+    if (
+      isValidEmail === "green" &&
+      isValidPhoneNumber === "green" &&
+      isValidConfirmPassword &&
+      containsTwoTypes === "green"
+    ) {
       mutation.mutate(formData);
       return;
     }
@@ -259,8 +255,8 @@ const SignupWrap = () => {
             <input
               className={cx({
                 mb16: true,
-                "border-red": isValidEmail === 1,
-                "input-text-red": isValidEmail === 1,
+                "border-red": isValidEmail === "red",
+                "input-text-red": isValidEmail === "red",
               })}
               type="text"
               ref={emailRef}
@@ -270,7 +266,7 @@ const SignupWrap = () => {
               onChange={emailChange}
               placeholder="이메일"
             />
-            {isValidEmail == 1 && (
+            {isValidEmail == "red" && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />
@@ -282,8 +278,8 @@ const SignupWrap = () => {
             <input
               className={cx({
                 mb16: true,
-                "border-red": isValidPhoneNumber === 1,
-                "input-text-red": isValidPhoneNumber === 1,
+                "border-red": isValidPhoneNumber === "red",
+                "input-text-red": isValidPhoneNumber === "red",
               })}
               ref={phoneNumberRef}
               type="phoneNumber"
@@ -293,7 +289,7 @@ const SignupWrap = () => {
               value={formData.phoneNumber}
               onChange={phoneNumberChange}
             />
-            {isValidPhoneNumber == 1 && (
+            {isValidPhoneNumber == "red" && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />
@@ -365,8 +361,8 @@ const SignupWrap = () => {
               <input
                 className={cx({
                   mb12: true,
-                  "border-red": isValidConfirmPassword == 1,
-                  "input-text-red": isValidConfirmPassword == 1,
+                  "border-red": isValidConfirmPassword == "red",
+                  "input-text-red": isValidConfirmPassword == "red",
                 })}
                 id="confirmPassword"
                 ref={confirmPasswordRef}
@@ -383,7 +379,7 @@ const SignupWrap = () => {
               </div>
             </div>
 
-            {isValidConfirmPassword == 1 && (
+            {isValidConfirmPassword == "red" && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />

--- a/src/pages/Signup/components/SignupWrap.tsx
+++ b/src/pages/Signup/components/SignupWrap.tsx
@@ -169,22 +169,22 @@ const SignupWrap = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (isValidEmail === "red" || isValidEmail === "gray") {
+    if (isValidEmail === CheckType.Red || isValidEmail === CheckType.Gray) {
       emailRef.current?.focus();
       setValidEmail(CheckType.Red);
       return;
     }
-    if (isValidPhoneNumber === "red" || isValidPhoneNumber === "gray") {
+    if (isValidPhoneNumber === CheckType.Red || isValidPhoneNumber === CheckType.Gray) {
       phoneNumberRef.current?.focus();
       setValidPhoneNumber(CheckType.Red);
       return;
     }
-    if (containsTwoTypes === "red" || containsTwoTypes === "gray") {
+    if (containsTwoTypes === CheckType.Red || containsTwoTypes === CheckType.Gray) {
       passwordRef.current?.focus();
       setContainsTwoTypes(CheckType.Red);
       return;
     }
-    if (isValidConfirmPassword === "red" || isValidConfirmPassword === "gray") {
+    if (isValidConfirmPassword === CheckType.Red || isValidConfirmPassword === CheckType.Gray) {
       confirmPasswordRef.current?.focus();
       setValidConfirmPassword(CheckType.Red);
       return;
@@ -195,10 +195,10 @@ const SignupWrap = () => {
       return;
     }
     if (
-      isValidEmail === "green" &&
-      isValidPhoneNumber === "green" &&
+      isValidEmail === CheckType.Green &&
+      isValidPhoneNumber === CheckType.Green &&
       isValidConfirmPassword &&
-      containsTwoTypes === "green"
+      containsTwoTypes === CheckType.Green
     ) {
       mutation.mutate(formData);
       return;
@@ -213,11 +213,11 @@ const SignupWrap = () => {
   const getIconSrc = (flag: string) => {
     console.log(flag);
     switch (flag) {
-      case "gray":
+      case CheckType.Gray:
         return "/image/icon_check.svg";
-      case "red":
+      case CheckType.Red:
         return "/image/icon_x_red.svg";
-      case "green":
+      case CheckType.Green:
         return "/image/icon_check_green.svg";
       default:
         null;
@@ -256,8 +256,8 @@ const SignupWrap = () => {
             <input
               className={cx({
                 mb16: true,
-                "border-red": isValidEmail === "red",
-                "input-text-red": isValidEmail === "red",
+                "border-red": isValidEmail === CheckType.Red,
+                "input-text-red": isValidEmail === CheckType.Red,
               })}
               type="text"
               ref={emailRef}
@@ -267,7 +267,7 @@ const SignupWrap = () => {
               onChange={emailChange}
               placeholder="이메일"
             />
-            {isValidEmail == "red" && (
+            {isValidEmail == CheckType.Red && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />
@@ -279,8 +279,8 @@ const SignupWrap = () => {
             <input
               className={cx({
                 mb16: true,
-                "border-red": isValidPhoneNumber === "red",
-                "input-text-red": isValidPhoneNumber === "red",
+                "border-red": isValidPhoneNumber === CheckType.Red,
+                "input-text-red": isValidPhoneNumber === CheckType.Red,
               })}
               ref={phoneNumberRef}
               type="phoneNumber"
@@ -290,7 +290,7 @@ const SignupWrap = () => {
               value={formData.phoneNumber}
               onChange={phoneNumberChange}
             />
-            {isValidPhoneNumber == "red" && (
+            {isValidPhoneNumber == CheckType.Red && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />
@@ -303,10 +303,10 @@ const SignupWrap = () => {
               <input
                 className={cx({
                   mb5: true,
-                  "border-red": containsTwoTypes === "red",
-                  "input-text-red": containsTwoTypes === "red",
-                  "border-green": containsTwoTypes === "green",
-                  "input-text-green": containsTwoTypes === "green",
+                  "border-red": containsTwoTypes === CheckType.Red,
+                  "input-text-red": containsTwoTypes === CheckType.Red,
+                  "border-green": containsTwoTypes === CheckType.Green,
+                  "input-text-green": containsTwoTypes === CheckType.Green,
                 })}
                 type={isViewHidden ? "password" : "text"}
                 ref={passwordRef}
@@ -327,8 +327,8 @@ const SignupWrap = () => {
                 <img src={getIconSrc(containsTwoTypes)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": containsTwoTypes === "green",
-                    "text-red": containsTwoTypes === "red",
+                    "text-green": containsTwoTypes === CheckType.Green,
+                    "text-red": containsTwoTypes === CheckType.Red,
                   })}
                 >
                   영문/숫자/특수문자 중, 2가지 이상 포함
@@ -338,8 +338,8 @@ const SignupWrap = () => {
                 <img src={getIconSrc(moreOrLess)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": moreOrLess === "green",
-                    "text-red": moreOrLess === "red",
+                    "text-green": moreOrLess === CheckType.Green,
+                    "text-red": moreOrLess === CheckType.Red,
                   })}
                 >
                   8자 이상 32자 이하 입력 (공백 제외)
@@ -350,8 +350,8 @@ const SignupWrap = () => {
                 <img src={getIconSrc(consecutiveChar)} alt="체크" />
                 <p
                   className={cx({
-                    "text-green": consecutiveChar === "green",
-                    "text-red": consecutiveChar === "red",
+                    "text-green": consecutiveChar === CheckType.Green,
+                    "text-red": consecutiveChar === CheckType.Red,
                   })}
                 >
                   연속 3자 이상 동일한 문자/숫자 제외
@@ -362,8 +362,8 @@ const SignupWrap = () => {
               <input
                 className={cx({
                   mb5: true,
-                  "border-red": isValidConfirmPassword == "red",
-                  "input-text-red": isValidConfirmPassword == "red",
+                  "border-red": isValidConfirmPassword == CheckType.Red,
+                  "input-text-red": isValidConfirmPassword == CheckType.Red,
                 })}
                 id="confirmPassword"
                 ref={confirmPasswordRef}
@@ -380,7 +380,7 @@ const SignupWrap = () => {
               </div>
             </div>
 
-            {isValidConfirmPassword == "red" && (
+            {isValidConfirmPassword == CheckType.Red && (
               <div className="guide-section">
                 <div className="guide">
                   <img src="image/icon_x_red.svg" alt="체크" />

--- a/src/pages/Signup/components/SignupWrap.tsx
+++ b/src/pages/Signup/components/SignupWrap.tsx
@@ -13,6 +13,7 @@ interface FormData {
   password: string;
   confirmPassword: string;
 }
+// 회원가입 체크 3가지 상태 정의
 enum CheckType {
   Gray = "gray",
   Red = "red",
@@ -31,9 +32,9 @@ const SignupWrap = () => {
   const phoneNumberRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const [containsTwoTypes, setContainsTwoTypes] = useState<CheckType>(CheckType.Gray);
-  const [moreOrLess, setMoreOrLess] = useState<CheckType>(CheckType.Gray);
-  const [consecutiveChar, setConsecutiveChar] = useState<CheckType>(CheckType.Gray);
+  const [containsTwoTypes, setContainsTwoTypes] = useState<CheckType>(CheckType.Gray); //영문/숫자/특수문자 중, 2가지 이상 포함
+  const [moreOrLess, setMoreOrLess] = useState<CheckType>(CheckType.Gray); //8자 이상 32자 이하 입력 (공백 제외)
+  const [consecutiveChar, setConsecutiveChar] = useState<CheckType>(CheckType.Gray); //연속 3자 이상 동일한 문자/숫자 제외
   const [isViewHidden, setIsViewHidden] = useState<boolean>(true);
   const [isViewHiddenConfirm, setIsViewHiddenConfirm] = useState<boolean>(true);
   const [isValidEmail, setValidEmail] = useState<CheckType>(CheckType.Gray); // 이메일이 유효한지 체크하는 state
@@ -360,7 +361,7 @@ const SignupWrap = () => {
             <div className="input-wraper">
               <input
                 className={cx({
-                  mb12: true,
+                  mb5: true,
                   "border-red": isValidConfirmPassword == "red",
                   "input-text-red": isValidConfirmPassword == "red",
                 })}
@@ -387,7 +388,7 @@ const SignupWrap = () => {
                 </div>
               </div>
             )}
-            <div className="s__checkbox-wrap">
+            <div className="s__checkbox-wrap mt10">
               <div className="s__checkbox">
                 <input type="checkbox" className="s__checkbox-total" id="ch01_all" />
                 <label htmlFor="ch01_all">모두 동의합니다.</label>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #156 

## 📝 작업 내용

```
enum CheckType {
  Gray = "gray",
  Red = "red",
  Green = "green",
}
```
회원가입 체크 상태의 3가지 표현을 gray, red, green으로 표현하게 바꿨습니다

비밀번호가 일치하지 않습니다 비밀번호 확인 input쪽에 붙였습니다
![image](https://github.com/user-attachments/assets/3626e32e-b1a0-4833-893c-5f1881c92744)


## 💬 리뷰 요구사항(선택)

- 변수명이 이해가 안가는 부분있으면 알려주세요 바꿔보겠습니다