### PR TITLE
[#240]fix: 시각화 디폴트 코드, True 색, 리턴될 때 위치

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1151,6 +1151,12 @@ header .group-btn {
 
   text-align: left;
 }
+.true {
+  background-color: #10D190 !important;
+}
+.border-true {
+  border: 1px solid #10D190 !important;
+}
 .false {
   background-color: #ff0000 !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1634,6 +1634,9 @@ gpt-icon-small {
   width: calc(100% + 2px);
   transform: translateX(-1px);
 }
+.highlight-func-title{
+  background-color: #f5f5fc !important;
+}
 .func-title span {
   display: inline-flex;
   align-items: center;

--- a/src/pages/Visualization/Visualization.tsx
+++ b/src/pages/Visualization/Visualization.tsx
@@ -18,7 +18,13 @@ import { useGptTooltipStore } from "@/store/gptTooltip";
 
 export default function Visualization() {
   const [code, setCode] = useState<any>(
-    ["a = 3", "for i in range(a):", "   print(' ' * ((a - 1) - i), end = '')", "   print('*' * (2 * i + 1))"].join("\n")
+    ["\"\"\" Enter your python code \"\"\"\n" +
+    "\n" +
+    "# example\n" +
+    "for i in range(2, 10):\n" +
+    "   for j in range(1, 10):\n" +
+    "      print(f\"{i} x {j} = {i * j}\")\n" +
+    "   print()\n"].join("\n")
   );
   const [preprocessedCodes, setPreprocessedCodes] = useState<ValidTypeDto[]>([]);
   // zustand store

--- a/src/pages/Visualization/VisualizationClassroom.tsx
+++ b/src/pages/Visualization/VisualizationClassroom.tsx
@@ -34,7 +34,11 @@ interface ClassAccessRightDataType {
 
 const VisualizationClassroom = () => {
   const [code, setCode] = useState<any>(
-    ["a = 3", "for i in range(a):", "   print(' ' * ((a - 1) - i), end = '')", "   print('*' * (2 * i + 1))"].join("\n")
+      ["# example\n" +
+      "for i in range(2, 10):\n" +
+      "   for j in range(1, 10):\n" +
+      "      print(f\"{i} x {j} = {i * j}\")\n" +
+      "   print()\n"].join("\n")
   );
   const [preprocessedCodes, setPreprocessedCodes] = useState<ValidTypeDto[]>([]);
   const navigate = useNavigate();

--- a/src/pages/Visualization/components/LeftSection/LeftSection.module.css
+++ b/src/pages/Visualization/components/LeftSection/LeftSection.module.css
@@ -105,7 +105,7 @@
   background: var(--white, #fff);
 }
 .default-option button {
-  color: var(--gray01, #dddee4);
+  /*color: var(--gray01, #dddee4);*/
   text-align: center;
   font-family: Pretendard;
   font-size: 16px;

--- a/src/pages/Visualization/components/LeftSection/LeftSection.module.css
+++ b/src/pages/Visualization/components/LeftSection/LeftSection.module.css
@@ -105,7 +105,7 @@
   background: var(--white, #fff);
 }
 .default-option button {
-  /*color: var(--gray01, #dddee4);*/
+  /*color: var(--gray01, #dddee4);*/  /* 디폴트값 gray 주석 해제 */
   text-align: center;
   font-family: Pretendard;
   font-size: 16px;

--- a/src/pages/Visualization/components/RightSection/RightSection.tsx
+++ b/src/pages/Visualization/components/RightSection/RightSection.tsx
@@ -152,8 +152,7 @@ const RightSection = () => {
         setConsole([errorMessage]);
         setPreprocessedCodes([]);
         return;
-
-      } else if(error.code == 'CA-400007'){
+      } else if (error.code == "CA-400007") {
         alert("코드의 실행 횟수가 너무 많습니다.");
 
         return;
@@ -187,17 +186,21 @@ const RightSection = () => {
         intervalRef.current = setInterval(onForward, 1000);
       } else if (selectedValue === "2x") {
         intervalRef.current = setInterval(onForward, 500);
+      } else if (selectedValue === "3x") {
+        intervalRef.current = setInterval(onForward, 300);
+      } else if (selectedValue === "0.5x") {
+        intervalRef.current = setInterval(onForward, 2000);
+      } else {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
       }
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
+      return () => {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+      };
     }
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
   }, [isPlaying, consoleIdx, codeFlowLength]);
 
   useEffect(() => {

--- a/src/pages/Visualization/components/RightSection/RightSection.tsx
+++ b/src/pages/Visualization/components/RightSection/RightSection.tsx
@@ -614,8 +614,10 @@ const RightSection = () => {
             </p>
             <p className="ml24 fz14">Play Speed</p>
             <select name="" id="" className="s__select ml14" value={selectedValue} onChange={handleChange}>
+              <option value="0.5x">0.5X</option>
               <option value="1x">1X</option>
               <option value="2x">2X</option>
+              <option value="3x">3X</option>
             </select>
           </div>
         </div>

--- a/src/pages/Visualization/components/RightSection/components/CallUserFuncBox/CallUserFuncBox.module.css
+++ b/src/pages/Visualization/components/RightSection/components/CallUserFuncBox/CallUserFuncBox.module.css
@@ -59,6 +59,7 @@
   display: flex;
   align-items: flex-end;
   padding-bottom: 16px;
+  margin-top: 15px;
 }
 .func-val::after {
   content: "";

--- a/src/pages/Visualization/components/RightSection/components/CallUserFuncBox/CallUserFuncBox.tsx
+++ b/src/pages/Visualization/components/RightSection/components/CallUserFuncBox/CallUserFuncBox.tsx
@@ -26,7 +26,7 @@ const CallUserFuncBox = ({ callUserFuncItem, children }: CallUserFuncProps): Rea
       )}
       <div className={cx("code-flow", "code-flow-func", isLight && "highlight-border")}>
         <div className={"code-flow-title-wrap"}>
-          <div className={"func-title"}>
+          <div className={cx("func-title", isLight && "highlight-func-title")}>
             <span className={cx(isLight && "highlight-border")}>{signature}</span>
           </div>
         </div>

--- a/src/pages/Visualization/components/RightSection/components/CodeFlowVariableBox/CodeFlowVariableBox.module.css
+++ b/src/pages/Visualization/components/RightSection/components/CodeFlowVariableBox/CodeFlowVariableBox.module.css
@@ -29,6 +29,11 @@ span {
   align-items: center;
   justify-content: center;
 }
+.align-center > span {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: normal;
+}
 .highlight {
   background-color: #364fce;
 }

--- a/src/pages/Visualization/components/RightSection/components/ElifBox/ElifBox.tsx
+++ b/src/pages/Visualization/components/RightSection/components/ElifBox/ElifBox.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import styles from "./ElifBox.module.css";
 import cx from "classnames";
 import { AnimatePresence, motion } from "framer-motion";
 import { ConditionItem } from "@/pages/Visualization/types/codeFlow/conditionItem";
@@ -18,7 +17,10 @@ function ElifBox({ children, isLight, elifItem }: Props) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.3 }}
-        className={cx("code-flow", isLight && "highlight-border")}
+        className={cx("code-flow",
+            isLight && "highlight-border",
+            isLight && elifItem.expr === "False" && "border-false",
+            isLight && elifItem.expr === "True" && "border-true")}
       >
         <motion.div
           layout
@@ -33,7 +35,12 @@ function ElifBox({ children, isLight, elifItem }: Props) {
           </motion.div>
           <div className="code-flow-var">
             <div>
-              <span className={cx(isLight && "highlight-number", isLight && elifItem.expr === "False" && styles.false)}>
+              <span className={cx(
+                  isLight && "highlight-number",
+                  isLight && elifItem.expr === "True" && "true",
+                  isLight && elifItem.expr === "False" && "false"
+                )}
+              >
                 {elifItem.expr?.split("").map((char, index) => (
                   <span key={index} style={{ all: "unset" }}>
                     {char}

--- a/src/pages/Visualization/components/RightSection/components/ElseBox/ElseBox.tsx
+++ b/src/pages/Visualization/components/RightSection/components/ElseBox/ElseBox.tsx
@@ -16,7 +16,10 @@ function ElseBox({ children, isLight, elseItem }: Props) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.3 }}
-        className={cx("code-flow", isLight && "highlight-border")}
+        className={cx("code-flow",
+            isLight && "highlight-border",
+            isLight && elseItem.expr === "False" && "border-false",
+            isLight && elseItem.expr === "True" && "border-true")}
       >
         <motion.div
           layout
@@ -33,7 +36,7 @@ function ElseBox({ children, isLight, elseItem }: Props) {
           <div className="code-flow-var">
             <div>
               {elseItem.expr === "True" ? (
-                <motion.span layout className={cx(isLight && "highlight-number")}>
+                <motion.span layout className={cx(isLight && "true")}>
                   True
                 </motion.span>
               ) : null}

--- a/src/pages/Visualization/components/RightSection/components/IfBox/IfBox.tsx
+++ b/src/pages/Visualization/components/RightSection/components/IfBox/IfBox.tsx
@@ -14,7 +14,10 @@ function IfBox({ children, isLight, ifItem }: Props) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.3 }}
-        className={cx("code-flow", isLight && "highlight-border", isLight && ifItem.expr === "False" && "border-false")}
+        className={cx("code-flow",
+            isLight && "highlight-border",
+            isLight && ifItem.expr === "False" && "border-false",
+            isLight && ifItem.expr === "True" && "border-true")}
       >
         <motion.div
           layout
@@ -29,7 +32,12 @@ function IfBox({ children, isLight, ifItem }: Props) {
           </motion.div>
           <div className="code-flow-var">
             <div>
-              <span className={cx(isLight && "highlight-number", isLight && ifItem.expr === "False" && "false")}>
+              <span className={cx(
+                  isLight && "highlight-number",
+                  isLight && ifItem.expr === "True" && "true",
+                  isLight && ifItem.expr === "False" && "false"
+                  )}
+              >
                 {ifItem.expr?.split("").map((char, index) => (
                   <span key={index} style={{ all: "unset" }}>
                     {char}

--- a/src/pages/Visualization/components/RightSection/components/ReturnBox/ReturnBox.module.css
+++ b/src/pages/Visualization/components/RightSection/components/ReturnBox/ReturnBox.module.css
@@ -23,7 +23,7 @@
   min-width: 10px;
   border-radius: 4px;
   color: #fff;
-  padding: 8px 15px;
+  padding: 10px 15px;
   position: relative;
 }
 .return-data p.data-true {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #240

## 📝 작업 내용

- **시각화 디폴트 코드 수정**
<img width="546" alt="image" src="https://github.com/user-attachments/assets/5b7bca47-ec8c-4ebc-a3bd-c495c2881153">

- **True 색 변경**
<img width="581" alt="image" src="https://github.com/user-attachments/assets/bd44f82d-b86b-4d63-8286-b064148f4ddb">

- **리턴 될 때 위치 수정 - 비슷하게 함**
<img width="592" alt="image" src="https://github.com/user-attachments/assets/3cb60027-c8e7-4537-af0e-672900cbf603">
<img width="592" alt="image" src="https://github.com/user-attachments/assets/24a27787-6466-41b2-92b4-cbfcd2b5b07e">

- **함수 선택될 때 배경색도 하이라이트**
<img width="523" alt="image" src="https://github.com/user-attachments/assets/b559b8fe-4257-48f6-b6a9-fa10b736201f">



### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
