### PR TITLE
[#269]fix: return 값이 없을 때 오류 수정

### DIFF
--- a/src/pages/Visualization/components/RightSection/components/ReturnBox/ReturnBox.tsx
+++ b/src/pages/Visualization/components/RightSection/components/ReturnBox/ReturnBox.tsx
@@ -8,10 +8,12 @@ function ReturnBox({ returnItem }: Props) {
   const { returnExpr, isLight } = returnItem;
   return (
     <div className={cx("code-flow-data")}>
-      {returnExpr !== "" && (
+      {returnExpr !== "" ? (
         <div className={cx(styles["return-data"])}>
           <p className={cx(isLight && styles["highlight"], returnExpr == "False" && styles["data-false"])}>{returnExpr}</p>
         </div>
+      ): (
+        <div className={cx(styles["return-data"])}></div>
       )}
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #269 

## 📝 작업 내용

- eturn 값이 없을 때 오류 수정

### 스크린샷 (선택)
<img width="542" alt="스크린샷 2024-11-13 15 56 10" src="https://github.com/user-attachments/assets/221ee726-81cc-4878-bd6e-959a66ee7d1a">


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
